### PR TITLE
Add a logic to allow policy to tell state machine if it should transit to Closed state.

### DIFF
--- a/src/failure_policy.rs
+++ b/src/failure_policy.rs
@@ -78,7 +78,8 @@ where
     BACKOFF: Iterator<Item = Duration> + Clone,
 {
     assert!(
-        (0.0..=1.0).contains(&required_success_rate) || (-1.0..=0.0).contains(&required_success_rate),
+        (0.0..=1.0).contains(&required_success_rate)
+            || (-1.0..=0.0).contains(&required_success_rate),
         "required_success_rate must be [0, 1] or [-1,0]: {}",
         required_success_rate
     );
@@ -168,10 +169,11 @@ where
     /// We can trigger failure accrual if the `window` has passed, success rate is below
     /// `required_success_rate`.
     fn can_remove(&mut self, success_rate: f64) -> bool {
-        if self.elapsed_millis() < self.window_millis ||
-            self.request_counter.sum() < i64::from(self.min_request_threshold) {
+        if self.elapsed_millis() < self.window_millis
+            || self.request_counter.sum() < i64::from(self.min_request_threshold)
+        {
             return false;
-            }
+        }
         if self.required_success_rate > 0.0 {
             success_rate < self.required_success_rate
         } else {
@@ -183,7 +185,6 @@ where
     pub fn success_rate(&self) -> f64 {
         self.ema.last()
     }
-
 }
 
 impl<BACKOFF> FailurePolicy for SuccessRateOverTimeWindow<BACKOFF>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,5 +92,5 @@ pub use self::error::Error;
 pub use self::failure_policy::FailurePolicy;
 pub use self::failure_predicate::FailurePredicate;
 pub use self::instrument::Instrument;
-pub use self::state_machine::{State, StateMachine};
+pub use self::state_machine::StateMachine;
 pub use self::windowed_adder::WindowedAdder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,6 @@
 
 mod circuit_breaker;
 mod config;
-mod ema;
 mod error;
 mod failure_predicate;
 mod instrument;
@@ -78,6 +77,8 @@ mod state_machine;
 mod windowed_adder;
 
 pub mod backoff;
+/// ema
+pub mod ema;
 pub mod failure_policy;
 #[cfg(feature = "futures-support")]
 pub mod futures;
@@ -91,5 +92,5 @@ pub use self::error::Error;
 pub use self::failure_policy::FailurePolicy;
 pub use self::failure_predicate::FailurePredicate;
 pub use self::instrument::Instrument;
-pub use self::state_machine::StateMachine;
+pub use self::state_machine::{State, StateMachine};
 pub use self::windowed_adder::WindowedAdder;

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use parking_lot::Mutex;
 
 use super::clock;
-use super::failure_policy::{Decision, FailurePolicy};
+use super::failure_policy::FailurePolicy;
 use super::instrument::Instrument;
 
 const ON_CLOSED: u8 = 0b0000_0001;
@@ -14,8 +14,8 @@ const ON_REJECTED: u8 = 0b0000_0100;
 const ON_OPEN: u8 = 0b0000_1000;
 
 /// States of the state machine.
-#[derive(Debug, Clone)]
-pub enum State {
+#[derive(Debug)]
+enum State {
     /// A closed breaker is operating normally and allowing.
     Closed,
     /// An open breaker has tripped and will not allow requests through until an interval expired.
@@ -178,13 +178,6 @@ where
         }
     }
 
-    /// Current state
-    ///
-    pub fn current_state(&self) -> State {
-        let shared = self.inner.shared.lock();
-        shared.state.clone()
-    }
-
     /// Records a successful call.
     ///
     /// This method must be invoked when a call was success.
@@ -192,18 +185,11 @@ where
         let mut instrument: u8 = 0;
         {
             let mut shared = self.inner.shared.lock();
-            let decision = shared.failure_policy.record_success();
-            if let Some(decision) = decision {
-                if matches!(decision, Decision::Close) && !matches!(shared.state, State::Closed) {
-                    shared.transit_to_closed();
-                    instrument |= ON_CLOSED;
-                }
-            } else {
-                if let State::HalfOpen(_) = shared.state {
-                    shared.transit_to_closed();
-                    instrument |= ON_CLOSED;
-                }
+            if let State::HalfOpen(_) = shared.state {
+                shared.transit_to_closed();
+                instrument |= ON_CLOSED;
             }
+            shared.failure_policy.record_success()
         }
 
         if instrument & ON_CLOSED != 0 {


### PR DESCRIPTION
A successful request calls record_success() on the policy, which will return Option<Decision>. If the decision is Close then state machine should transit to Closed state. If the decision is SkipStateChange then the state machine should not attempt any state transition. If there is no decision by the policy, i.e. record_success() returns None, the state machine uses its existing logic.

Without this change the state machine transits to Closed state only if (1) current state is HalfOpen and (2) a single success request event is recorded.

With this change a policy may be used to observe responses of multiple requests while circuit breaker is triggered, in order to make sure that it is ok to turn off the circuit breaker.